### PR TITLE
#7 - Making favicon and tab title not required fields.

### DIFF
--- a/src/_mocks/mocks.ts
+++ b/src/_mocks/mocks.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs/Observable';
 import { IRule } from '../app/rule/common/rule-model';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { convertToParamMap, ParamMap } from '@angular/router';
+import { RuleBrowserStorageService } from '../app/rule/common';
 
 export class MockedNotificationService {
   notifySuccess(message: string) {
@@ -15,7 +16,7 @@ export class MockedNotificationService {
   }
 }
 
-export class MockedChromeStorageService {
+export class MockedRuleBrowserStorageService {
   setAll(rules: IRule[]): Observable<any> {
     return Observable.of({});
   }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -8,12 +8,12 @@ import { AppMaterialModule } from './app-material.module';
 import { AppStore } from './store/app.store';
 import { NotificationService } from './common/notification.service';
 
-import { MockedChromeStorageService, MockedNotificationService, MockedRouter } from '../_mocks/mocks';
+import { MockedRuleBrowserStorageService, MockedNotificationService, MockedRouter } from '../_mocks/mocks';
 
 import { HeaderComponent } from './_layout/header.component';
 import { AppComponent } from './app.component';
 import { RuleActions } from './rule/common/rule.actions';
-import { ChromeStorageService, RuleService } from './rule/common/';
+import { RuleBrowserStorageService, RuleService } from './rule/common/';
 import { Icon, IIcon, IRule, Rule } from './rule/common/rule-model';
 
 class MockedRuleService {
@@ -43,7 +43,7 @@ describe('AppComponent', () => {
         { provide: Router, useClass: MockedRouter },
         { provide: RuleActions, useValue: new RuleActions() },
         { provide: NotificationService, useClass: MockedNotificationService },
-        { provide: ChromeStorageService, useClass: MockedChromeStorageService },
+        { provide: RuleBrowserStorageService, useClass: MockedRuleBrowserStorageService },
         { provide: RuleService, useClass: MockedRuleService }
       ],
       declarations: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,7 +12,7 @@ import { HeaderComponent } from './_layout/';
 import { NotificationService, BrowserStorageProvider } from './common';
 import { AppStore } from './store/';
 
-import { RuleDashboardComponent, RuleDetailsComponent, RuleService, ChromeStorageService, RuleActions } from './rule';
+import { RuleDashboardComponent, RuleDetailsComponent, RuleService, RuleBrowserStorageService, RuleActions } from './rule';
 
 @NgModule({
   declarations: [
@@ -36,7 +36,7 @@ import { RuleDashboardComponent, RuleDetailsComponent, RuleService, ChromeStorag
     { provide: 'Chrome',  useValue: chrome },
     RuleService,
     NotificationService,
-    ChromeStorageService,
+    RuleBrowserStorageService,
     RuleActions,
     BrowserStorageProvider
   ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { AppMaterialModule } from './app-material.module';
 import { rootRouterConfig } from './app-routes';
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './_layout/';
-import { NotificationService } from './common';
+import { NotificationService, BrowserStorageProvider } from './common';
 import { AppStore } from './store/';
 
 import { RuleDashboardComponent, RuleDetailsComponent, RuleService, ChromeStorageService, RuleActions } from './rule';
@@ -33,10 +33,12 @@ import { RuleDashboardComponent, RuleDetailsComponent, RuleService, ChromeStorag
     AppStore,
   ],
   providers: [
+    { provide: 'Chrome',  useValue: chrome },
     RuleService,
     NotificationService,
     ChromeStorageService,
-    RuleActions
+    RuleActions,
+    BrowserStorageProvider
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/common/browser-storage-provider.service.spec.ts
+++ b/src/app/common/browser-storage-provider.service.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { BrowserStorageProvider, StorageType } from './browser-storage-provider.service';
+
+describe('BrowserStorageProvider', () => {
+  let storageService: BrowserStorageProvider;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        BrowserStorageProvider,
+        { provide: 'Chrome', useValue: { storage: void(0) } }
+      ]
+    });
+  });
+
+  beforeEach(() => {
+    storageService = TestBed.get(BrowserStorageProvider);
+  });
+
+  it('should be created', () => {
+    expect(storageService).toBeTruthy();
+  });
+
+  it('should return localStorage if chrome is not available', () => {
+    const storage = storageService.getStorage();
+
+    expect(storage.type).toEqual(StorageType.LocalStorage);
+    expect(storage.storage).toBeDefined();
+  });
+});
+
+describe('BrowserStorageProvider', () => {
+  let storageService: BrowserStorageProvider;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        BrowserStorageProvider,
+        { provide: 'Chrome', useValue: { storage: {} } }
+      ]
+    });
+  });
+
+  beforeEach(() => {
+    storageService = TestBed.get(BrowserStorageProvider);
+  });
+
+  it('should be created', () => {
+    expect(storageService).toBeTruthy();
+  });
+
+  it('should return chrome storage if available', () => {
+    const storage = storageService.getStorage();
+
+    expect(storage.type).toEqual(StorageType.Chrome);
+    expect(storage.storage).toBeDefined();
+  });
+});
+

--- a/src/app/common/browser-storage-provider.service.ts
+++ b/src/app/common/browser-storage-provider.service.ts
@@ -1,0 +1,36 @@
+import { Inject, Injectable } from '@angular/core';
+
+export interface IStorage {
+  storage: any;
+  type: StorageType;
+}
+
+export enum StorageType {
+  Chrome,
+  LocalStorage
+}
+
+@Injectable()
+export class BrowserStorageProvider {
+
+  constructor(@Inject('Chrome') private chrome) {
+
+  }
+
+  /**
+   * Returns the available store on the browser.
+   * @returns {IStorage}
+   */
+  getStorage (): IStorage {
+    if (this.chrome !== undefined && this.chrome.storage !== undefined) {
+      return <IStorage> {
+        storage: this.chrome.storage,
+        type: StorageType.Chrome
+      };
+    }
+    return  <IStorage> {
+      storage: localStorage,
+      type: StorageType.LocalStorage
+    };
+  }
+}

--- a/src/app/common/index.ts
+++ b/src/app/common/index.ts
@@ -1,1 +1,2 @@
 export * from './notification.service';
+export * from './browser-storage-provider.service';

--- a/src/app/rule/common/index.ts
+++ b/src/app/rule/common/index.ts
@@ -2,5 +2,5 @@ export * from './rule-model';
 export * from './rule.reducer';
 export * from './rule.actions';
 export * from './rule.effects';
-export * from './chrome-storage.service';
+export * from './rule-browser-storage.service';
 export * from './rule.service';

--- a/src/app/rule/common/rule-browser-storage.service.spec.ts
+++ b/src/app/rule/common/rule-browser-storage.service.spec.ts
@@ -1,0 +1,122 @@
+import { TestBed } from '@angular/core/testing';
+import { RuleBrowserStorageService } from './rule-browser-storage.service';
+import { BrowserStorageProvider } from '../../common';
+import { IStorage, StorageType } from '../../common';
+
+class MockedBrowserStorageProvider {
+  // used to mock chrome.
+  public useChromeStorage: boolean;
+
+  public mockedChrome = {
+    sync: {
+      set: function (items: any) {
+      },
+      get: function (key: string) {
+      }
+    }
+  };
+  public mockedLocalStorage = {
+    setItem: function () {
+    },
+    getItem: function () {
+    },
+    length: 0
+  };
+
+  getStorage(): IStorage {
+    if (this.useChromeStorage) {
+      return <IStorage> {
+        storage: this.mockedChrome,
+        type: StorageType.Chrome
+      };
+    }
+    return <IStorage> {
+      storage: this.mockedLocalStorage,
+      type: StorageType.LocalStorage
+    };
+  }
+
+}
+
+describe('RuleBrowserStorageService', () => {
+  let ruleBrowserStorageService: RuleBrowserStorageService;
+  let browserStorageProvider: MockedBrowserStorageProvider;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        RuleBrowserStorageService,
+        { provide: BrowserStorageProvider, useClass: MockedBrowserStorageProvider }
+      ]
+    });
+  });
+
+  beforeEach(() => {
+
+  });
+
+  it('should be created', () => {
+    ruleBrowserStorageService = TestBed.get(RuleBrowserStorageService);
+    browserStorageProvider = TestBed.get(BrowserStorageProvider);
+    expect(ruleBrowserStorageService).toBeTruthy();
+  });
+
+  it('chrome storage - should call get all', () => {
+    // sets mock to return chrome storage
+    browserStorageProvider = TestBed.get(BrowserStorageProvider);
+    browserStorageProvider.useChromeStorage = true;
+
+    ruleBrowserStorageService = TestBed.get(RuleBrowserStorageService);
+    spyOn(browserStorageProvider.mockedChrome.sync, 'get');
+
+    // Act
+    ruleBrowserStorageService.getAll();
+
+    expect(browserStorageProvider.mockedChrome.sync.get).toHaveBeenCalled();
+  });
+
+  it('chrome storage - should call set all', () => {
+    // sets mock to return chrome storage
+    browserStorageProvider = TestBed.get(BrowserStorageProvider);
+    browserStorageProvider.useChromeStorage = true;
+
+    ruleBrowserStorageService = TestBed.get(RuleBrowserStorageService);
+    spyOn(browserStorageProvider.mockedChrome.sync, 'set');
+
+    // Act
+    ruleBrowserStorageService.setAll([]);
+
+    expect(browserStorageProvider.mockedChrome.sync.set).toHaveBeenCalled();
+  });
+
+  it('local storage - should call get all', () => {
+    // sets mock to return local storage
+    browserStorageProvider = TestBed.get(BrowserStorageProvider);
+    browserStorageProvider.useChromeStorage = false;
+
+    ruleBrowserStorageService = TestBed.get(RuleBrowserStorageService);
+    spyOn(browserStorageProvider.mockedLocalStorage, 'getItem');
+
+    // Act
+    ruleBrowserStorageService.getAll();
+
+    expect(browserStorageProvider.mockedLocalStorage.getItem).toHaveBeenCalled();
+  });
+
+  it('local storage - should call set all', () => {
+    // sets mock to return local storage
+    browserStorageProvider = TestBed.get(BrowserStorageProvider);
+    browserStorageProvider.useChromeStorage = false;
+
+    ruleBrowserStorageService = TestBed.get(RuleBrowserStorageService);
+    spyOn(browserStorageProvider.mockedLocalStorage, 'setItem');
+
+    // Act
+    ruleBrowserStorageService.setAll([]);
+
+    expect(browserStorageProvider.mockedLocalStorage.setItem).toHaveBeenCalled();
+  });
+
+});
+
+

--- a/src/app/rule/common/rule-browser-storage.service.ts
+++ b/src/app/rule/common/rule-browser-storage.service.ts
@@ -6,7 +6,7 @@ import { IRule, StorageRules } from './rule-model';
 import { IStorage, StorageType, BrowserStorageProvider } from '../../common';
 
 @Injectable()
-export class ChromeStorageService {
+export class RuleBrowserStorageService {
 
   private storage_key = 'envGuard';
   private browserStorage: IStorage;
@@ -21,7 +21,7 @@ export class ChromeStorageService {
    */
   setAll(rules: IRule[]): Observable<any> {
     const storage = new StorageRules(rules);
-    return Observable.from(new Promise((resolve, reject) => {
+    return Observable.from(new Promise((resolve, _) => {
       if (this.browserStorage.type === StorageType.Chrome) {
         this.browserStorage.storage.sync.set(storage, () => {
           resolve(true);
@@ -36,8 +36,8 @@ export class ChromeStorageService {
   /**
    * gets all rules from either local or chrome storage.
    */
-  getAllFromLocalStorage(): Observable<IRule[]> {
-    return Observable.from(new Promise((resolve, reject) => {
+  getAll(): Observable<IRule[]> {
+    return Observable.from(new Promise((resolve, _) => {
       if (this.browserStorage.type === StorageType.Chrome) {
         this.browserStorage.storage.sync.get(this.storage_key, (items: any) => {
           resolve(items[this.storage_key]);

--- a/src/app/rule/common/rule-model.ts
+++ b/src/app/rule/common/rule-model.ts
@@ -47,9 +47,9 @@ export class RuleBanner implements IRuleBanner {
   bgColor: string;
   textColor: string;
 
-  constructor(text: string, bgColor: string, textColor: string) {
+  constructor(text: string, icon: Icon, textColor: string = '#FFF') {
     this.text = text;
-    this.bgColor = bgColor;
+    this.bgColor = (icon ? icon.iconBaseColor : '#EB1342'); // default is empty is red.
     this.textColor = textColor;
   }
 }

--- a/src/app/rule/common/rule.service.spec.ts
+++ b/src/app/rule/common/rule.service.spec.ts
@@ -1,19 +1,19 @@
 import { async, TestBed } from '@angular/core/testing';
-import { ChromeStorageService } from './index';
+import { RuleBrowserStorageService } from './index';
 import { RuleService } from './rule.service';
 import { HttpClientModule } from '@angular/common/http';
 import { Icon, IIcon, IRule, Rule } from './rule-model';
 import { Observable } from 'rxjs/Observable';
 
-class MockedChromeStorageService {
+class MockedRuleBrowserStorageService {
 
   public static mockedRules: IRule[] = [
     new Rule(null, 'Production', 'http://production.com', 'Exact', 'Production', null),
     new Rule(null, 'Staging', 'http://staging.com', 'Exact', 'Staging', null)
   ];
 
-  getAllFromLocalStorage$: Observable<IRule[]> = Observable.of(MockedChromeStorageService.mockedRules);
-  getAllFromLocalStorage(): Observable<IRule[]> {
+  getAllFromLocalStorage$: Observable<IRule[]> = Observable.of(MockedRuleBrowserStorageService.mockedRules);
+  getAll(): Observable<IRule[]> {
     return this.getAllFromLocalStorage$;
   }
 
@@ -24,13 +24,13 @@ class MockedChromeStorageService {
 
 describe('RuleService', () => {
   let ruleService: RuleService;
-  let chromeStorageService: ChromeStorageService;
+  let ruleBrowserStorageService: RuleBrowserStorageService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientModule],
       providers: [
-        { provide: ChromeStorageService, useClass: MockedChromeStorageService },
+        { provide: RuleBrowserStorageService, useClass: MockedRuleBrowserStorageService },
         RuleService
       ]
     });
@@ -38,7 +38,7 @@ describe('RuleService', () => {
 
   beforeEach(() => {
     ruleService = TestBed.get(RuleService);
-    chromeStorageService = TestBed.get(ChromeStorageService);
+    ruleBrowserStorageService = TestBed.get(RuleBrowserStorageService);
   });
 
   it('should create service', () => {
@@ -52,20 +52,20 @@ describe('RuleService', () => {
   });
 
   it('should get all rules from chrome storage', () => {
-    spyOn(chromeStorageService, 'getAllFromLocalStorage').and.callThrough();
+    spyOn(ruleBrowserStorageService, 'getAll').and.callThrough();
 
     ruleService.getAllRules().subscribe((rules: IRule[]) => {
-      expect(rules).toEqual(MockedChromeStorageService.mockedRules);
-      expect(chromeStorageService.getAllFromLocalStorage).toHaveBeenCalled();
+      expect(rules).toEqual(MockedRuleBrowserStorageService.mockedRules);
+      expect(ruleBrowserStorageService.getAll).toHaveBeenCalled();
     });
   });
 
   it('should call save rules on chrome storage service', () => {
-    spyOn(chromeStorageService, 'setAll').and.callThrough();
-    const expectedRules = MockedChromeStorageService.mockedRules;
+    spyOn(ruleBrowserStorageService, 'setAll').and.callThrough();
+    const expectedRules = MockedRuleBrowserStorageService.mockedRules;
 
     ruleService.saveRules(expectedRules).subscribe(() => {
-      expect(chromeStorageService.setAll).toHaveBeenCalledWith(expectedRules);
+      expect(ruleBrowserStorageService.setAll).toHaveBeenCalledWith(expectedRules);
     });
   });
 

--- a/src/app/rule/common/rule.service.spec.ts
+++ b/src/app/rule/common/rule.service.spec.ts
@@ -47,7 +47,7 @@ describe('RuleService', () => {
 
   it('should get default icons', () => {
     ruleService.getDefaultIcons().subscribe((icons: IIcon[]) => {
-      expect(icons.length).toBe(3);
+      expect(icons.length).toBe(4);
     });
   });
 

--- a/src/app/rule/common/rule.service.ts
+++ b/src/app/rule/common/rule.service.ts
@@ -3,14 +3,14 @@ import { HttpClient } from '@angular/common/http';
 import 'rxjs/add/operator/map';
 import { Observable } from 'rxjs/Observable';
 
-import { ChromeStorageService } from './chrome-storage.service';
+import { RuleBrowserStorageService } from './rule-browser-storage.service';
 import { IIcon, IRule } from './rule-model';
 
 @Injectable()
 export class RuleService {
 
   constructor(private http: HttpClient,
-              private chromeStorage: ChromeStorageService) {  }
+              private chromeStorage: RuleBrowserStorageService) {  }
 
   /**
    * Returns the list of default icons
@@ -38,6 +38,6 @@ export class RuleService {
    * @returns {Observable<IRule[]>}
    */
   getAllRules(): Observable<IRule[]> {
-    return this.chromeStorage.getAllFromLocalStorage();
+    return this.chromeStorage.getAll();
   }
 }

--- a/src/app/rule/dashboard/rule-dashboard.component.html
+++ b/src/app/rule/dashboard/rule-dashboard.component.html
@@ -25,8 +25,8 @@
       <ng-container matColumnDef="icon">
         <mat-header-cell *matHeaderCellDef> Icon</mat-header-cell>
         <mat-cell *matCellDef="let element">
-          <img class="md-img-select mat-icon-16x" src="assets/{{element.icon.path}}">
-          {{element.icon.name}}
+          <img class="md-img-select mat-icon-16x" *ngIf="element.icon" src="assets/{{element.icon.path}}">
+          {{element.icon?.name}}
         </mat-cell>
       </ng-container>
 

--- a/src/app/rule/dashboard/rule-dashboard.component.spec.ts
+++ b/src/app/rule/dashboard/rule-dashboard.component.spec.ts
@@ -6,13 +6,13 @@ import { By } from '@angular/platform-browser';
 import { Store } from '@ngrx/store';
 
 import { AppStore } from '../../store/app.store';
-import { MockedChromeStorageService, MockedNotificationService, MockedRouter } from '../../../_mocks/mocks';
+import { MockedRuleBrowserStorageService, MockedNotificationService, MockedRouter } from '../../../_mocks/mocks';
 
 import { RuleDashboardComponent } from './rule-dashboard.component';
 import { NotificationService } from '../../common/notification.service';
 
 import { Icon, IIcon, IRule, Rule } from '../common/rule-model';
-import { ChromeStorageService, RuleActions, RuleService } from '../common/';
+import { RuleBrowserStorageService, RuleActions, RuleService } from '../common/';
 import { IAppStore } from '../../store/common/store.model';
 
 class MockedRuleService {
@@ -57,7 +57,7 @@ describe('RuleDashboardComponent', () => {
         { provide: Router, useClass: MockedRouter },
         { provide: RuleActions, useValue: new RuleActions() },
         { provide: NotificationService, useClass: MockedNotificationService },
-        { provide: ChromeStorageService, useClass: MockedChromeStorageService },
+        { provide: RuleBrowserStorageService, useClass: MockedRuleBrowserStorageService },
         { provide: RuleService, useClass: MockedRuleService }
       ],
       declarations: [RuleDashboardComponent]

--- a/src/app/rule/dashboard/rule-dashboard.component.spec.ts
+++ b/src/app/rule/dashboard/rule-dashboard.component.spec.ts
@@ -24,7 +24,8 @@ public static mockedIcons: IIcon[] = [
 
   public static mockedRules: IRule[] = [
     new Rule(null, 'Production', 'http://production.com', 'Exact', 'Production', MockedRuleService.mockedIcons[0]),
-    new Rule(null, 'Staging', 'http://staging.com', 'Exact', 'Staging', MockedRuleService.mockedIcons[1])
+    new Rule(null, 'Staging', 'http://staging.com', 'Exact', 'Staging', MockedRuleService.mockedIcons[1]),
+    new Rule('ABC', 'Development', 'http://dev.com', 'Exact', '', void(0))
   ];
 
   getAllRules$: Observable<IRule[]> = Observable.of(MockedRuleService.mockedRules);
@@ -82,6 +83,20 @@ describe('RuleDashboardComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show three rules on dashboard', () => {
+   fixture.detectChanges();
+
+    const matRows = fixture.nativeElement.querySelectorAll('mat-row');
+    expect(matRows.length).toBe(3);
+  });
+
+  it('should show rule without icon on dashboard', () => {
+    fixture.detectChanges();
+
+    const iconCells = fixture.nativeElement.querySelectorAll('.mat-cell.cdk-column-icon');
+    expect(iconCells[2].innerText).toBe('');
   });
 
   it('add new rule - navigate to details page with add on route', () => {

--- a/src/app/rule/dashboard/rule-dashboard.component.ts
+++ b/src/app/rule/dashboard/rule-dashboard.component.ts
@@ -55,6 +55,10 @@ export class RuleDashboardComponent implements OnInit {
     copy.id = uuid();
     copy.name = `${rule.name} - Copy`;
     this.store.dispatch(this.ruleActions.addRule(copy));
+
+    // TODO: This should be refactored and listen to ActionSubject
+    this.store.dispatch(this.ruleActions.syncLocalStorage());
+
     this.notificationService.notifySuccess('Rule duplicated!');
   }
 

--- a/src/app/rule/details/rule-details.component.html
+++ b/src/app/rule/details/rule-details.component.html
@@ -14,7 +14,7 @@
             <div class="row mb-3">
               <div class="col-lg-10 col-md-12 col-sm-12">
                 <mat-form-field class="input-full">
-                  <input matInput placeholder="Rule alias" formControlName="name">
+                  <input matInput placeholder="Rule alias *" formControlName="name">
                   <mat-error *ngIf="ruleForm.controls.name.errors">
                     Rule alias is <strong>required</strong>
                   </mat-error>
@@ -25,14 +25,14 @@
             <div class="row mb-2">
               <div class="col-lg-3 col-md-12 col-sm-12">
                 <mat-form-field class="input-full">
-                  <mat-select placeholder="Operator" formControlName="operator">
+                  <mat-select placeholder="Operator *" formControlName="operator">
                     <mat-option *ngFor="let key of operatorKeys" [value]="key">{{operatorRules[key]}}</mat-option>
                   </mat-select>
                 </mat-form-field>
               </div>
               <div class="col-lg-7 col-md-12 col-sm-12">
                 <mat-form-field class="input-full">
-                  <input matInput placeholder="URL" formControlName="url">
+                  <input matInput placeholder="URL *" formControlName="url">
                   <mat-error *ngIf="ruleForm.controls.url.errors">
                     URL is <strong>required</strong>
                   </mat-error>
@@ -55,12 +55,12 @@
                               formControlName="icon"
                               #select="matSelect">
                     <mat-select-trigger>
-                      <img class="md-img-select mat-icon-16x" src="assets/{{getIcon(select.selected?.value)?.path}}"
-                           alt="{{ select.selected?.viewValue }}">
+                      <img *ngIf="select.selected?.value != 'none'" class="md-img-select mat-icon-16x" src="assets/{{getIcon(select.selected?.value)?.path}}"
+                                                           alt="{{ select.selected?.viewValue }}">
                       {{ select.selected?.viewValue }}
                     </mat-select-trigger>
                     <mat-option layout="row" layout-align="start center" *ngFor="let icon of icons" [value]="icon.key">
-                      <img class="md-img-select mat-icon-16x" src="assets/{{icon.path}}" alt="{{ icon.name }}"> {{
+                      <img class="md-img-select mat-icon-16x" *ngIf="icon.path" src="assets/{{icon.path}}" alt="{{ icon.name }}"> {{
                       icon.name }}
                     </mat-option>
                   </mat-select>
@@ -108,7 +108,7 @@
       </mat-card-content>
     </form>
     <div class="mt-4">
-      <button data-spec-save mat-raised-button color="primary" (click)="save()">Save</button>
+      <button data-spec-save mat-raised-button color="primary" [disabled]="!ruleForm.valid" (click)="save()">Save</button>
       <button data-spec-cancel mat-raised-button (click)="cancel()">Cancel</button>
     </div>
   </mat-card>

--- a/src/app/rule/details/rule-details.component.spec.ts
+++ b/src/app/rule/details/rule-details.component.spec.ts
@@ -9,12 +9,12 @@ import { AppMaterialModule } from '../../app-material.module';
 import { NotificationService } from '../../common/notification.service';
 import {
   MockedActivatedRoute,
-  MockedChromeStorageService,
+  MockedRuleBrowserStorageService,
   MockedNotificationService,
   MockedRouter
 } from '../../../_mocks/mocks';
 
-import { ChromeStorageService, IRuleBanner, RuleActions, RuleBanner, RuleService } from '../common/';
+import { RuleBrowserStorageService, IRuleBanner, RuleActions, RuleBanner, RuleService } from '../common/';
 import { RuleDetailsComponent } from './rule-details.component';
 import { Icon, IIcon, IRule, Rule } from '../common/rule-model';
 import { Store } from '@ngrx/store';
@@ -69,7 +69,7 @@ describe('RuleDetailsComponent', () => {
         { provide: ActivatedRoute, useValue: activateRoute },
         { provide: RuleActions, useValue: new RuleActions() },
         { provide: NotificationService, useClass: MockedNotificationService },
-        { provide: ChromeStorageService, useClass: MockedChromeStorageService },
+        { provide: RuleBrowserStorageService, useClass: MockedRuleBrowserStorageService },
         { provide: RuleService, useClass: MockedRuleService }
       ],
       declarations: [RuleDetailsComponent]

--- a/src/app/rule/details/rule-details.component.ts
+++ b/src/app/rule/details/rule-details.component.ts
@@ -64,7 +64,7 @@ export class RuleDetailsComponent implements OnInit {
    * @returns {IIcon}
    */
   getIcon(key: string): IIcon {
-    if (key && this.icons) {
+    if (key && key !== 'none' && this.icons) {
       return this.icons.find(i => i.key === key);
     }
   }
@@ -84,6 +84,10 @@ export class RuleDetailsComponent implements OnInit {
    * Saves or updates a rule
    */
   save() {
+
+    if (!this.ruleForm.valid){
+      return;
+    }
     const rule = new Rule(
       this.ruleForm.value.id,
       this.ruleForm.value.name,
@@ -118,7 +122,7 @@ export class RuleDetailsComponent implements OnInit {
    */
   private initializeBanner() {
     const icon = this.getIcon(this.ruleForm.value.icon);
-    this.addBannerFormGroup(new RuleBanner(this.ruleForm.value.name, icon.iconBaseColor, '#FFF'));
+    this.addBannerFormGroup(new RuleBanner(this.ruleForm.value.name, icon));
   }
 
   /**
@@ -141,7 +145,7 @@ export class RuleDetailsComponent implements OnInit {
       url: [currentRule.url, [Validators.required]],
       operator: [currentRule.operator, [Validators.required]],
       title: [currentRule.title],
-      icon: [(currentRule.icon) ? currentRule.icon.key : '', [Validators.required]]
+      icon: [(currentRule.icon) ? currentRule.icon.key : 'none']
     });
 
     if (this.currentRule.banner) {

--- a/src/assets/default-icons.json
+++ b/src/assets/default-icons.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "None",
+    "key": "none",
+    "path": "",
+    "iconBaseColor": ""
+  },
+  {
     "name": "Production",
     "key": "prod",
     "path": "icons/red.png",

--- a/src/content.js
+++ b/src/content.js
@@ -7,7 +7,7 @@
    * @param rule
    */
   function changeTabTitle(rule) {
-    if (rule.title === null) {
+    if (!rule.title) {
       return;
     }
     document.title = rule.title;
@@ -18,7 +18,7 @@
    * @param rule
    */
   function changeTabIcon(rule) {
-    if (rule.icon === null)
+    if (!rule.icon)
       return;
 
     var el = document.querySelectorAll('head link[rel*="icon"]');


### PR DESCRIPTION
Now users can create rule without having to modify the Title or the Favicon of the tab. Addded more tests to cover new scenarios. Closes #7 