### PR TITLE
Extension crashes on Chrome version 64.0.3282.119

### DIFF
--- a/src/app/rule/details/rule-details.component.html
+++ b/src/app/rule/details/rule-details.component.html
@@ -55,13 +55,13 @@
                               formControlName="icon"
                               #select="matSelect">
                     <mat-select-trigger>
-                      <img *ngIf="select.selected?.value != 'none'" class="md-img-select mat-icon-16x" src="assets/{{getIcon(select.selected?.value)?.path}}"
+                      <img *ngIf="select.selected && select.selected.value != 'none'" class="md-img-select mat-icon-16x" src="assets/{{getIcon(select.selected?.value)?.path}}"
                                                            alt="{{ select.selected?.viewValue }}">
                       {{ select.selected?.viewValue }}
                     </mat-select-trigger>
                     <mat-option layout="row" layout-align="start center" *ngFor="let icon of icons" [value]="icon.key">
-                      <img class="md-img-select mat-icon-16x" *ngIf="icon.path" src="assets/{{icon.path}}" alt="{{ icon.name }}"> {{
-                      icon.name }}
+                      <img class="md-img-select mat-icon-16x" *ngIf="icon.path" src="assets/{{icon.path}}" alt="{{ icon.name }}">
+                      {{ icon.name }}
                     </mat-option>
                   </mat-select>
                 </mat-form-field>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "name": "Env-Guard",
   "description": "No more mistakes in production.",
   "author": "Joao Grassi",


### PR DESCRIPTION
Fixing an issue with angular material mat-select-trigger firing a request to /assets folder. This was triggering the content verification on Chrome making the extension disabled.